### PR TITLE
Fix #2 of "Add your service account credentials"

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ You'll now use Jenkins to define and run a pipeline that will test, build, and d
 First we will need to configure our GCP credentials in order for Jenkins to be able to access our code repository
 
 1. In the Jenkins UI, Click “Credentials” on the left
-1. Click “Global Credentials”
+1. Click either of the “(global)” links (they both route to the same URL)
 1. Click “Add Credentials” on the left
 1. From the “Kind” dropdown, select “Google Service Account from metadata”
 1. Click “OK”


### PR DESCRIPTION
Problem:
Step #2 says to click "Global Credentials", but there is no link or button on the page with this name. The link is actually called "(global)".

![screenshot 2016-10-13 09 03 22](https://cloud.githubusercontent.com/assets/550486/19352377/41897d6e-9125-11e6-9764-a5f46cf2b3b0.png)

Fix:
I updated the step to correctly instruct the user to click "(global)"