### PR TITLE
Fix Phase 3 initial paragraph wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ Create a branch for the staging environment called `staging`
     $ git checkout -b staging
    ```
 
-The `Jenkinsfile` is written using the Jenkins Workflow DSL (Groovy-based). It allows an entire build pipeline to be expressed in a single script that lives along side supports your source code and powerful features like parallelization, stages, and user input.
+The [`Jenkinsfile`](https://jenkins.io/doc/book/pipeline/jenkinsfile/) is written using the Jenkins Workflow DSL (Groovy-based). It allows an entire build pipeline to be expressed in a single script that lives alongside your source code and supports powerful features like parallelization, stages, and user input.
 
 Modify your `Jenkinsfile` script so it contains the correct project name on line 2.
 


### PR DESCRIPTION
Problem:
The first paragraph of the Phase 3 section was worded a little strangely, which could make it difficult for the reader to follow along. 

Fix:
I corrected the grammatical errors, and added a link for the official documentation to `Jenkinsfile`.