### PR TITLE
Fix readme indentation & formatting of code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,8 @@ Often times changes will not be so trivial that they can be pushed directly to t
 all you need to do is push it up to the Git server and let Jenkins deploy your environment. In this case you will not use a loadbalancer so you'll have to access your application using `kubectl proxy`,
 which authenticates itself with the Kuberentes API and proxies requests from your local machine to the service in the cluster without exposing your service to the internet.
 
+#### Deploy the development branch
+
 1. Create another branch and push it up to the Git server
 
    ```shell
@@ -484,15 +486,34 @@ which authenticates itself with the Kuberentes API and proxies requests from you
    $ git push origin new-feature
    ```
 
-   You should see that a new job has been created and your environment is being created. At the bottom of the console output of the job you will see instructions for accessing your environment. Namely:
+1. Open Jenkins in your web browser and navigate to the sample-app job. You should see that a new job called "new-feature" has been created and your environment is being created.
 
-1. Start the proxy
+1. Navigate to the console output of the first build of this new job by:
+
+  * Click the `new-feature` link in the job list.
+  * Click the `#1` link in the Build History list on the left of the page.
+  * Finally click the `Console Output` link in the left navigation.
+
+1. Scroll to the bottom of the console output of the job, and you will see instructions for accessing your environment:
+
+   ```
+   deployment "gceme-frontend-dev" created
+   [Pipeline] echo
+   To access your environment run `kubectl proxy`
+   [Pipeline] echo
+   Then access your service via http://localhost:8001/api/v1/proxy/namespaces/new-feature/services/gceme-frontend:80/
+   [Pipeline] }
+   ```
+
+#### Access the development branch
+
+1. Open a new Google Cloud Shell terminal by clicking the `+` button to the right of the current terminal's tab, and start the proxy:
 
    ```shell
    $ kubectl proxy
    ```
 
-1. Access your application via localhost:
+1. Return to the original shell, and access your application via localhost:
 
    ```shell
    $ curl http://localhost:8001/api/v1/proxy/namespaces/new-feature/services/gceme-frontend:80/


### PR DESCRIPTION
~~I think this'll be the last PR. I'm almost done following the tutorial. :)~~

(Definitely not the last PR. I see a few more issues at the end of the tutorial).

Problem:
The code blocks are not formatted consistently. Since the file source is not typically
viewed, this isn't a huge problem. However, at least tree of the code blocks in
"Phase 5: Deploy a development branch" are not rendered correctly due to the formatting
issues:

* Step 1 of the deployment section is showing the `shell` tag for the code block as part of the code, and the line breaks are not being rendered.

* Step 1 of the access section is also showing the `shell` tag for the code block.

Additionally, the instructions to view the new job and it's console output are terse and vague. It is assumed that the reader is familiar with Jenkins and knows how to access these things.

Fix:

I reformatted the code blocks so they are all consistent:

* All blocks are indented with 3 spaces
* All blocks have a blank line above and below them
* The "Deploy" vs "Access" stages of the "Deploy a development branch" have been more clearly defined, with full instructions on how to access the Console Output of the Jenkins build.

Before:
![screenshot 2016-10-14 17 32 10](https://cloud.githubusercontent.com/assets/550486/19404543/4d95f500-9234-11e6-8798-03cb0bd34b8a.png)

After:
![screenshot 2016-10-14 17 32 00](https://cloud.githubusercontent.com/assets/550486/19404551/571c4782-9234-11e6-8de9-142ea78e9a0e.png)