### PR TITLE
Fix & clarify phase 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,46 +470,72 @@ Often times changes will not be so trivial that they can be pushed directly to t
 all you need to do is push it up to the Git server and let Jenkins deploy your environment. In this case you will not use a loadbalancer so you'll have to access your application using `kubectl proxy`,
 which authenticates itself with the Kuberentes API and proxies requests from your local machine to the service in the cluster without exposing your service to the internet.
 
+#### Deploy the development branch
+
 1. Create another branch and push it up to the Git server
+
    ```shell
-    $ git checkout -b new-feature
-    $ git push origin new-feature
+   $ git checkout -b new-feature
+   $ git push origin new-feature
    ```
 
-You should see that a new job has been created and your environment is being created. At the bottom of the console output of the job
-you will see instructions for accessing your environment. Namely:
+1. Open Jenkins in your web browser and navigate to the sample-app job. You should see that a new job called "new-feature" has been created and your environment is being created.
 
-1. Start the proxy
-    ```shell
-    $ kubectl proxy
+1. Navigate to the console output of the first build of this new job by:
+
+  * Click the `new-feature` link in the job list.
+  * Click the `#1` link in the Build History list on the left of the page.
+  * Finally click the `Console Output` link in the left navigation.
+
+1. Scroll to the bottom of the console output of the job, and you will see instructions for accessing your environment:
+
    ```
-1. Access your application via localhost:
-    ```shell
-    $ curl http://localhost:8001/api/v1/proxy/namespaces/new-feature/services/gceme-frontend:80/
+   deployment "gceme-frontend-dev" created
+   [Pipeline] echo
+   To access your environment run `kubectl proxy`
+   [Pipeline] echo
+   Then access your service via http://localhost:8001/api/v1/proxy/namespaces/new-feature/services/gceme-frontend:80/
+   [Pipeline] }
+   ```
+
+#### Access the development branch
+
+1. Open a new Google Cloud Shell terminal by clicking the `+` button to the right of the current terminal's tab, and start the proxy:
+
+   ```shell
+   $ kubectl proxy
+   ```
+
+1. Return to the original shell, and access your application via localhost:
+
+   ```shell
+   $ curl http://localhost:8001/api/v1/proxy/namespaces/new-feature/services/gceme-frontend:80/
    ```
 
 1. You can now push code to this branch in order to update your development environment. Once you are done, merge your branch back
 into master to deploy that code to the staging environment:
-    ```shell
-    $ git checkout master
-    $ git merge new-feature
-    $ git push master
+
+   ```shell
+   $ git checkout master
+   $ git merge new-feature
+   $ git push master
    ```
 
 1. When you are confident that your code won't wreak havoc in production merge from the `master` branch to the `production` branch. Your code
  will be automatically rolled out in the production environment:
- ```shell
-    $ git checkout production
-    $ git merge master
-    $ git push production
+ 
+   ```shell
+   $ git checkout production
+   $ git merge master
+   $ git push production
    ```
 
 1. When you are done with your development branch, delete it from the server and delete the environment in Kubernetes:
- ```shell
-    $ git push origin :new-feature
-    $ kubectl delete ns new-feature
-   ```
 
+   ```shell
+   $ git push origin :new-feature
+   $ kubectl delete ns new-feature
+   ```
 
 ## Extra credit: deploy a breaking change, then roll back
 Make a breaking change to the `gceme` source, push it, and deploy it through the pipeline to production. Then pretend latency spiked after the deployment and you want to roll back. Do it! Faster!


### PR DESCRIPTION
Problem:

The code blocks are not formatted consistently. Since the file source is not typically viewed, this isn't a huge problem. However, at least tree of the code blocks in "Phase 5: Deploy a development branch" are not rendered correctly due to the formatting issues:

* Step 1 of the deployment section is showing the `shell` tag for the code block as part of the code, and the line breaks are not being rendered.

* Step 1 of the access section is also showing the `shell` tag for the code block.

Additionally, the instructions to view the new job and it's console output are terse and vague. It is assumed that the reader is familiar with Jenkins and knows how to access these things.

Fix:

* I reformatted the code blocks in phase 5 so they are consistent
* All blocks are indented with 3 spaces
* All blocks have a blank line above and below them
* The "Deploy" vs "Access" stages of the "Deploy a development branch" have been more clearly defined, with full instructions on how to access the Console Output of the Jenkins build.

Before:
![screenshot 2016-10-14 17 32 10](https://cloud.githubusercontent.com/assets/550486/19404543/4d95f500-9234-11e6-8798-03cb0bd34b8a.png)

After:
![screenshot 2016-10-14 17 32 00](https://cloud.githubusercontent.com/assets/550486/19404551/571c4782-9234-11e6-8de9-142ea78e9a0e.png)