### PR TITLE
Fix branch and remote names in phase 5.

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,22 +512,22 @@ which authenticates itself with the Kuberentes API and proxies requests from you
    $ curl http://localhost:8001/api/v1/proxy/namespaces/new-feature/services/gceme-frontend:80/
    ```
 
-1. You can now push code to this branch in order to update your development environment. Once you are done, merge your branch back
-into master to deploy that code to the staging environment:
+1. You can now push code to the `new-feature` branch in order to update your development environment.
+
+1. Once you are done, merge your `new-feature ` branch back into the  `staging` branch to deploy that code to the staging environment:
+
+   ```shell
+   $ git checkout staging
+   $ git merge new-feature
+   $ git push origin staging
+   ```
+
+1. When you are confident that your code won't wreak havoc in production, merge from the `staging` branch to the `master` branch. Your code will be automatically rolled out in the production environment:
 
    ```shell
    $ git checkout master
-   $ git merge new-feature
-   $ git push master
-   ```
-
-1. When you are confident that your code won't wreak havoc in production merge from the `master` branch to the `production` branch. Your code
- will be automatically rolled out in the production environment:
- 
-   ```shell
-   $ git checkout production
-   $ git merge master
-   $ git push production
+   $ git merge staging
+   $ git push origin master
    ```
 
 1. When you are done with your development branch, delete it from the server and delete the environment in Kubernetes:


### PR DESCRIPTION
Problem:
Steps within phase 5 are referring to the wrong branch names when instructing the reader to deploy to staging and production.

For example, the document refers to a `production` branch, which is actually `master` (see Jenkinsfile:30).

Additionally, the git push commands did not include the remote name, and were instead just instructing the reader to `git push master`. This will only work if you have configured an upstream branch, which if the reader had followed the tutorial word for word, would not have.

Fix:
I corrected all of the branch names and added the missing remote argument to the git push commands.