### PR TITLE
Fix securing jenkins breaks ingress.

### DIFF
--- a/jenkins/k8s/jenkins.yaml
+++ b/jenkins/k8s/jenkins.yaml
@@ -30,6 +30,14 @@ spec:
         ports:
         - containerPort: 8080
         - containerPort: 50000
+        readinessProbe:
+          httpGet:
+            path: /login
+            port: 8080
+          periodSeconds: 1
+          timeoutSeconds: 1
+          successThreshold: 1
+          failureThreshold: 10
         env:
         - name: JENKINS_OPTS
           valueFrom:

--- a/jenkins/k8s/jenkins.yaml
+++ b/jenkins/k8s/jenkins.yaml
@@ -34,10 +34,10 @@ spec:
           httpGet:
             path: /login
             port: 8080
-          periodSeconds: 1
-          timeoutSeconds: 1
-          successThreshold: 1
-          failureThreshold: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+          successThreshold: 2
+          failureThreshold: 5
         env:
         - name: JENKINS_OPTS
           valueFrom:


### PR DESCRIPTION
Problem:
Securing the Jenkins installation by enabling matrix based authorization prevents the user from accessing Jenkins via the Ingress load balancer.

Cause:
The load balancer is polling the Jenkins host web root, which returns a 403 when authorization is not allowing anonymous access. This causes the Ingress load balancer to believe the host is not available.

Fix:
I added the readinessProbe to the Jenkins Deployment as suggested by @ryane. This causes Ingress to poll /login instead of the host web root, which responds with a 200 OK for anonymous requests.

Fixes #21