### PR TITLE
Rename staging environment to canary.

### DIFF
--- a/sample-app/Jenkinsfile
+++ b/sample-app/Jenkinsfile
@@ -17,18 +17,18 @@ node {
 
   stage "Deploy Application"
   switch (env.BRANCH_NAME) {
-    // Roll out to staging
-    case "staging":
-        // Change deployed image in staging to the one we just built
-        sh("sed -i.bak 's#gcr.io/cloud-solutions-images/gceme:1.0.0#${imageTag}#' ./k8s/staging/*.yaml")
+    // Roll out to canary environment
+    case "canary":
+        // Change deployed image in canary to the one we just built
+        sh("sed -i.bak 's#gcr.io/cloud-solutions-images/gceme:1.0.0#${imageTag}#' ./k8s/canary/*.yaml")
         sh("kubectl --namespace=production apply -f k8s/services/")
-        sh("kubectl --namespace=production apply -f k8s/staging/")
+        sh("kubectl --namespace=production apply -f k8s/canary/")
         sh("echo http://`kubectl --namespace=production get service/${feSvcName} --output=json | jq -r '.status.loadBalancer.ingress[0].ip'` > ${feSvcName}")
         break
 
     // Roll out to production
     case "master":
-        // Change deployed image in staging to the one we just built
+        // Change deployed image in canary to the one we just built
         sh("sed -i.bak 's#gcr.io/cloud-solutions-images/gceme:1.0.0#${imageTag}#' ./k8s/production/*.yaml")
         sh("kubectl --namespace=production apply -f k8s/services/")
         sh("kubectl --namespace=production apply -f k8s/production/")

--- a/sample-app/k8s/canary/backend-canary.yaml
+++ b/sample-app/k8s/canary/backend-canary.yaml
@@ -15,19 +15,19 @@
 kind: Deployment
 apiVersion: extensions/v1beta1
 metadata:
-  name: gceme-frontend-staging
+  name: gceme-backend-canary
 spec:
-  replicas:
+  replicas: 1
   template:
     metadata:
-      name: frontend
+      name: backend
       labels:
         app: gceme
-        role: frontend
-        env: staging
+        role: backend
+        env: canary
     spec:
       containers:
-      - name: frontend
+      - name: backend
         image: gcr.io/cloud-solutions-images/gceme:1.0.0
         resources:
           limits:
@@ -37,8 +37,8 @@ spec:
         readinessProbe:
           httpGet:
             path: /healthz
-            port: 80
-        command: ["sh", "-c", "app -frontend=true -backend-service=http://gceme-backend:8080 -port=80"]
+            port: 8080
+        command: ["sh", "-c", "app -port=8080"]
         ports:
-        - name: frontend
-          containerPort: 80
+        - name: backend
+          containerPort: 8080

--- a/sample-app/k8s/canary/frontend-canary.yaml
+++ b/sample-app/k8s/canary/frontend-canary.yaml
@@ -15,19 +15,19 @@
 kind: Deployment
 apiVersion: extensions/v1beta1
 metadata:
-  name: gceme-backend-staging
+  name: gceme-frontend-canary
 spec:
-  replicas: 1
+  replicas:
   template:
     metadata:
-      name: backend
+      name: frontend
       labels:
         app: gceme
-        role: backend
-        env: staging
+        role: frontend
+        env: canary
     spec:
       containers:
-      - name: backend
+      - name: frontend
         image: gcr.io/cloud-solutions-images/gceme:1.0.0
         resources:
           limits:
@@ -37,8 +37,8 @@ spec:
         readinessProbe:
           httpGet:
             path: /healthz
-            port: 8080
-        command: ["sh", "-c", "app -port=8080"]
+            port: 80
+        command: ["sh", "-c", "app -frontend=true -backend-service=http://gceme-backend:8080 -port=80"]
         ports:
-        - name: backend
-          containerPort: 8080
+        - name: frontend
+          containerPort: 80


### PR DESCRIPTION
Requirement:
Issue #11 confirms that the environment named staging in the repo is actually using the canary pattern, and should be named as such.

Implementation:
Mostly just a find and replace on the word staging vs canary. However I did ensure that the first instance of the word canary is a link to Martin Fowler's Canary Release article, and removed the statement claiming that staging (canary) and production environments are isolated.

Resolves #11