### PR TITLE
Use "jenkins/jenkins" docker image

### DIFF
--- a/jenkins/k8s/jenkins.yaml
+++ b/jenkins/k8s/jenkins.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: master
-        image: jenkinsci/jenkins:2.67
+        image: jenkins/jenkins:2.67
         ports:
         - containerPort: 8080
         - containerPort: 50000


### PR DESCRIPTION
The `jenkinsci/jenkins` is deprecated in favour of `jenkins/jenkins`. ---> https://hub.docker.com/r/jenkinsci/jenkins/