### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,16 +429,16 @@ You can use the [labels](http://kubernetes.io/docs/user-guide/labels/) `env: pro
 1. Track the output for a few minutes and watch for the `kubectl --namespace=production apply...` to begin. When it starts, open the terminal that's polling canary's `/version` URL and observe it start to change in some of the requests:
 
    ```
-  1.0.0
-  1.0.0
-  1.0.0
-  1.0.0
-  2.0.0
-  2.0.0
-  1.0.0
-  1.0.0
-  1.0.0
-  1.0.0
+   1.0.0
+   1.0.0
+   1.0.0
+   1.0.0
+   2.0.0
+   2.0.0
+   1.0.0
+   1.0.0
+   1.0.0
+   1.0.0
    ```
 
    You have now rolled out that change to a subset of users.


### PR DESCRIPTION
Before:

<img width="933" alt="capture d ecran 2017-10-13 a 15 30 16" src="https://user-images.githubusercontent.com/419078/31548544-747a08bc-b02b-11e7-8d65-9d4da1d63331.png">

After:

<img width="904" alt="capture d ecran 2017-10-13 a 15 31 00" src="https://user-images.githubusercontent.com/419078/31548581-8ac994f2-b02b-11e7-8abc-7d6306dd2bbd.png">
