### PR TITLE
Add JVM memory limit

### DIFF
--- a/jenkins/k8s/jenkins.yaml
+++ b/jenkins/k8s/jenkins.yaml
@@ -44,6 +44,8 @@ spec:
             secretKeyRef:
               name: jenkins
               key: options
+        - name: JAVA_OPTS
+          value: '-Xmx1400m'
         volumeMounts:
         - mountPath: /var/jenkins_home
           name: jenkins-home


### PR DESCRIPTION
The JVM doesn't respect the Kubernetes memory limit since the container and JVM cannot detect this limitation. When Jenkins exceeds its memory it will eventually get killed by Kubernetes. This can be prevented by setting a JVM memory maximum. 

See issue #99 