### PR TITLE
Use non-deprecated base

### DIFF
--- a/jenkins/docker-slave-image/Dockerfile
+++ b/jenkins/docker-slave-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkinsci/jnlp-slave
+FROM jenkins/jnlp-slave
 MAINTAINER Vic Iglesias <viglesias@google.com>
 
 ENV CLOUDSDK_CORE_DISABLE_PROMPTS 1


### PR DESCRIPTION
https://hub.docker.com/r/jenkins/jnlp-slave/

"Warning! This image used to be published as jenkinsci/jnlp-slave.
That image name is deprecated, use jenkins/jnlp-slave."