### PR TITLE
Fix project ID placeholder variable

### DIFF
--- a/sample-app/Jenkinsfile
+++ b/sample-app/Jenkinsfile
@@ -1,4 +1,4 @@
-def project = 'PROJECT_ID'
+def project = 'REPLACE_WITH_YOUR_PROJECT_ID'
 def  appName = 'gceme'
 def  feSvcName = "${appName}-frontend"
 def  imageTag = "gcr.io/${project}/${appName}:${env.BRANCH_NAME}.${env.BUILD_NUMBER}"


### PR DESCRIPTION
In the Qwiklab that references this repo ("Continuous Delivery with Jenkins in Kubernetes Engine"), the directions refer to the placeholder for Project ID in this file with the variable name REPLACE_WITH_YOUR_PROJECT_ID ... this change updates the Jenkinsfile to match those directions (also: the longer name gives clearer direction than the old name: PROJECT_ID).