### PR TITLE
Modify command of gcloud build

### DIFF
--- a/sample-app/Jenkinsfile
+++ b/sample-app/Jenkinsfile
@@ -51,7 +51,7 @@ spec:
     stage('Build and push image with Container Builder') {
       steps {
         container('gcloud') {
-          sh "PYTHONUNBUFFERED=1 gcloud container builds submit -t ${imageTag} ."
+          sh "PYTHONUNBUFFERED=1 gcloud builds submit -t ${imageTag} ."
         }
       }
     }


### PR DESCRIPTION
    Currently, build command has a fail. (Jenkinsfile line: 54)

    PYTHONUNBUFFERED=1 gcloud container builds submit -t gcr.io/REPLACE_WITH_YOUR_PROJECT_ID/gceme:master.1 .
    ERROR: (gcloud.container.builds.submit) This command has been replaced with .