### PR TITLE
Plugin update for workflow-job

### DIFF
--- a/jenkins/values.yaml
+++ b/jenkins/values.yaml
@@ -1,7 +1,7 @@
 Master:
   InstallPlugins:
     - kubernetes:1.12.6
-    - workflow-job:2.24
+    - workflow-job:2.31
     - workflow-aggregator:2.5
     - credentials-binding:1.16
     - git:3.9.1


### PR DESCRIPTION
-Updated workflow-job plugin version from 2.24 to 2.31

Changes against [Jenkins plugin workflow-job:2.24 too old?](https://github.com/GoogleCloudPlatform/continuous-deployment-on-kubernetes/issues/137) issue. 