### PR TITLE
remove partition: 1 and add security context

### DIFF
--- a/jenkins/k8s/jenkins.yaml
+++ b/jenkins/k8s/jenkins.yaml
@@ -24,9 +24,12 @@ spec:
       labels:
         app: master
     spec:
+      securityContext:
+        runAsUser: 1000
+        fsGroup: 1000
       containers:
       - name: master
-        image: jenkins/jenkins:2.67
+        image: jenkins/jenkins:2.162
         ports:
         - containerPort: 8080
         - containerPort: 50000
@@ -61,5 +64,4 @@ spec:
         gcePersistentDisk:
           pdName: jenkins-home
           fsType: ext4
-          partition: 1
 # [END jenkins_deployment]


### PR DESCRIPTION
use more recent version of Jenkins image - 2.162
remove partition: 1 from volumes that causes pod to unable to attach volume per https://github.com/kubernetes/kubernetes/issues/37253#issuecomment-264025021
add security context as newer images of jenkins use jenkins (uid=1000) as user