### PR TITLE
Bug: Fix apiVersion for backend-dev.yaml

### DIFF
--- a/sample-app/k8s/dev/backend-dev.yaml
+++ b/sample-app/k8s/dev/backend-dev.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 kind: Deployment
-apiVersion: app/v1
+apiVersion: apps/v1
 metadata:
   name: gceme-backend-dev
 spec:


### PR DESCRIPTION
Throws an error in jenkins while deploying.
Happens in qwiklabs lab: google.qwiklabs.com/focuses/1104

```
java.io.IOException: Failed to launch command args: [kubectl, --kubeconfig, /home/jenkins/agent/workspace/sample-app_new-feature@tmp/.kube3020155600159179657config, apply, --namespace, new-feature, -f, /home/jenkins/agent/workspace/sample-app_new-feature/k8s/dev], status: 1. Logs: resourcequota/default created
deployment.apps/gceme-frontend-dev created
error: unable to recognize "/home/jenkins/agent/workspace/sample-app_new-feature/k8s/dev/backend-dev.yaml": no matches for kind "Deployment" in version "app/v1"
```