### PR TITLE
Updated apiVersion For Lab: Continuous Deployment with Jenkins v1.6

### DIFF
--- a/sample-app/k8s/dev/backend-dev.yaml
+++ b/sample-app/k8s/dev/backend-dev.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 kind: Deployment
-apiVersion: app/v1
+apiVersion: apps/v1
 metadata:
   name: gceme-backend-dev
 spec:


### PR DESCRIPTION
- Updated apiVersion with apps/v1 replacing app/v1.
- Reference buganizer: http://b/154966198