### PR TITLE
Replacing "master" with "controller"

### DIFF
--- a/jenkins/values.yaml
+++ b/jenkins/values.yaml
@@ -1,4 +1,4 @@
-master:
+controller:
   installPlugins:
     - kubernetes:latest
     - workflow-job:latest


### PR DESCRIPTION
Latest versions of Jenkins replaced "master" with "controller".