### PR TITLE
Master -> Controller as Master is depricated by Helm

### DIFF
--- a/jenkins/values.yaml
+++ b/jenkins/values.yaml
@@ -1,4 +1,4 @@
-master:
+controler:
   installPlugins:
     - kubernetes:latest
     - workflow-job:latest


### PR DESCRIPTION
Error: template: jenkins/templates/deprecation.yaml:3:9: executing "jenkins/templates/deprecation.yaml" at <fail "`master` does no longer exist. It has been renamed to `controller`">: error calling fail: `master` does no longer exist. It has been renamed to `controller`