### PR TITLE
switch to docker registry to GCEME app

### DIFF
--- a/sample-app/k8s/canary/backend-canary.yaml
+++ b/sample-app/k8s/canary/backend-canary.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: backend
-        image: gcr.io/cloud-solutions-images/gceme:1.0.0
+        image: corelab/gceme:1.0.0
         resources:
           limits:
             memory: "500Mi"

--- a/sample-app/k8s/canary/frontend-canary.yaml
+++ b/sample-app/k8s/canary/frontend-canary.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: frontend
-        image: gcr.io/cloud-solutions-images/gceme:1.0.0
+        image: corelab/gceme:1.0.0
         resources:
           limits:
             memory: "500Mi"

--- a/sample-app/k8s/dev/backend-dev.yaml
+++ b/sample-app/k8s/dev/backend-dev.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: backend
-        image: gcr.io/cloud-solutions-images/gceme:1.0.0
+        image: corelab/gceme:1.0.0
         resources:
           limits:
             memory: "500Mi"

--- a/sample-app/k8s/dev/frontend-dev.yaml
+++ b/sample-app/k8s/dev/frontend-dev.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: frontend
-        image: gcr.io/cloud-solutions-images/gceme:1.0.0
+        image: corelab/gceme:1.0.0
         resources:
           limits:
             memory: "500Mi"

--- a/sample-app/k8s/production/backend-production.yaml
+++ b/sample-app/k8s/production/backend-production.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: backend
-        image: gcr.io/cloud-solutions-images/gceme:1.0.0
+        image: corelab/gceme:1.0.0
         resources:
           limits:
             memory: "500Mi"

--- a/sample-app/k8s/production/frontend-production.yaml
+++ b/sample-app/k8s/production/frontend-production.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: frontend
-        image: gcr.io/cloud-solutions-images/gceme:1.0.0
+        image: corelab/gceme:1.0.0
         resources:
           limits:
             memory: "500Mi"


### PR DESCRIPTION
The gceme sample app does not appear to exist on Google Container Registry anymore.

We're getting ImagePullBackOff errors and this is causing issues for material that uses this repo.

![image](https://user-images.githubusercontent.com/40506467/148059471-9afef6dc-e625-4804-8619-e8dc8e3cab84.png)
