### PR TITLE
Revert "switch to docker registry to GCEME app"

### DIFF
--- a/sample-app/k8s/canary/backend-canary.yaml
+++ b/sample-app/k8s/canary/backend-canary.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: backend
-        image: corelab/gceme:1.0.0
+        image: gcr.io/cloud-solutions-images/gceme:1.0.0
         resources:
           limits:
             memory: "500Mi"

--- a/sample-app/k8s/canary/frontend-canary.yaml
+++ b/sample-app/k8s/canary/frontend-canary.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: frontend
-        image: corelab/gceme:1.0.0
+        image: gcr.io/cloud-solutions-images/gceme:1.0.0
         resources:
           limits:
             memory: "500Mi"

--- a/sample-app/k8s/dev/backend-dev.yaml
+++ b/sample-app/k8s/dev/backend-dev.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: backend
-        image: corelab/gceme:1.0.0
+        image: gcr.io/cloud-solutions-images/gceme:1.0.0
         resources:
           limits:
             memory: "500Mi"

--- a/sample-app/k8s/dev/frontend-dev.yaml
+++ b/sample-app/k8s/dev/frontend-dev.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: frontend
-        image: corelab/gceme:1.0.0
+        image: gcr.io/cloud-solutions-images/gceme:1.0.0
         resources:
           limits:
             memory: "500Mi"

--- a/sample-app/k8s/production/backend-production.yaml
+++ b/sample-app/k8s/production/backend-production.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: backend
-        image: corelab/gceme:1.0.0
+        image: gcr.io/cloud-solutions-images/gceme:1.0.0
         resources:
           limits:
             memory: "500Mi"

--- a/sample-app/k8s/production/frontend-production.yaml
+++ b/sample-app/k8s/production/frontend-production.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: frontend
-        image: corelab/gceme:1.0.0
+        image: gcr.io/cloud-solutions-images/gceme:1.0.0
         resources:
           limits:
             memory: "500Mi"


### PR DESCRIPTION
Reverts GoogleCloudPlatform/continuous-deployment-on-kubernetes#177

Vulnerability scan of gceme:1.0.0 shows the following vulnerabilities: 

```
     35     effectiveSeverity: CRITICAL
    220     effectiveSeverity: HIGH
    362     effectiveSeverity: LOW
    373     effectiveSeverity: MEDIUM
```

"corelab" repo on dockerhub seems to be a independently maintained clone of gcr.io/cloud-solutions-images and not an official repo. https://github.com/Doublemine/gcr.io-mirror/blob/master/cloud-solutions-images.md

I have requested a maintainer of this repo to fix the issues
@cgrant 